### PR TITLE
Fix arithmetic error due to mismatched parentheses

### DIFF
--- a/@iss/extract_and_filter.m
+++ b/@iss/extract_and_filter.m
@@ -230,7 +230,7 @@ function o = extract_and_filter(o)
                             IFS = gather(IFS+o.TilePixelValueShift);
                             nPixelsOutsideRange = sum(sum(IFS>uint16(inf)));
                             if nPixelsOutsideRange>o.nPixelsOutsideTiffRangeThresh
-                                MaxValue = double((max(IFS(IFS>uint16(inf)))-o.TilePixelValueShift)/ExtractScale);
+                                MaxValue = double((max(IFS(IFS>uint16(inf)))-o.TilePixelValueShift))/ExtractScale;
                                 NewScaling = double(uint16(inf))/MaxValue;
                                 o.nPixelsOutsideTiffRange(t,c,r) = nPixelsOutsideRange;
                                 o.PixelsOutsideTiffRangeExtractScale(t,c,r) = NewScaling;

--- a/@iss/extract_and_filter_NoGPU.m
+++ b/@iss/extract_and_filter_NoGPU.m
@@ -230,7 +230,7 @@ function o = extract_and_filter_NoGPU(o)
                             IFS = IFS+o.TilePixelValueShift;
                             nPixelsOutsideRange = sum(sum(IFS>uint16(inf)));
                             if nPixelsOutsideRange>o.nPixelsOutsideTiffRangeThresh
-                                MaxValue = double((max(IFS(IFS>uint16(inf)))-o.TilePixelValueShift)/ExtractScale);
+                                MaxValue = double((max(IFS(IFS>uint16(inf)))-o.TilePixelValueShift))/ExtractScale;
                                 NewScaling = double(uint16(inf))/MaxValue;
                                 o.nPixelsOutsideTiffRange(t,c,r) = nPixelsOutsideRange;
                                 o.PixelsOutsideTiffRangeExtractScale(t,c,r) = NewScaling;


### PR DESCRIPTION
When performing division, integers can only be combined with integers of
the same class, or scalar doubles. The intention of this line seemed to
try to coerce the numerator into a double, but there is a parentheses
mismatch, which throws an error. This commit corrects the parentheses.

This is the bug I mentioned at the lab meeting. Attached is a screenshot
from my debugging.

![Screenshot from 2020-04-16 19-34-22](https://user-images.githubusercontent.com/25193231/79566945-5ac1ac80-8081-11ea-91b8-9a6902ee8ac0.png)