### PR TITLE
Use doubles to avoid class error in bxsfun

### DIFF
--- a/@iss/call_spots_pixel.m
+++ b/@iss/call_spots_pixel.m
@@ -102,7 +102,7 @@ for f = 1:nFiles
     load(cell2mat(o.PixelFileNames(f)));
     PeakGlobalYX = cell(nCodes,1);
     for GeneNo = 1:nCodes
-        PeakGlobalYX{GeneNo} = bsxfun(@plus,PeakLocalYX{GeneNo},o.TileOrigin(OriginalTile{GeneNo},:,rr));
+        PeakGlobalYX{GeneNo} = bsxfun(@plus,double(PeakLocalYX{GeneNo}),o.TileOrigin(OriginalTile{GeneNo},:,rr));
     end 
     % Clear memory by removing bad matches, pSpotScore<-5
     clearvars PeakLocalYX


### PR DESCRIPTION
The first array into bxsfun is int32 class, which throws the error
"mixed integer class inputs are not supported". To avoid this, we wrap
the first array in double(). The second array is already a double.
After this change, the entire bridge_process_template runs to
completion.

Attached are some screenshots from debugging.

![Screenshot from 2020-04-25 13-46-52](https://user-images.githubusercontent.com/25193231/80287959-95bb8400-8702-11ea-8d06-bf0959520362.png)

![Screenshot from 2020-04-25 14-04-04](https://user-images.githubusercontent.com/25193231/80287962-99e7a180-8702-11ea-99f1-31043656987c.png)